### PR TITLE
Feature/universe refactor

### DIFF
--- a/esp32-s3-box/Cargo.toml
+++ b/esp32-s3-box/Cargo.toml
@@ -61,7 +61,6 @@ icm42670 = { git = "https://github.com/jessebraham/icm42670/" }
 # ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs", rev = "32ca78087c481e04863e094cffde62517fd079b4" }
 mipidsi = "0.5.0"
 panic-halt = "0.2"
-tinybmp = "0.4.0"
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 # petgraph = "0.6.2"

--- a/esp32-s3-box/src/main.rs
+++ b/esp32-s3-box/src/main.rs
@@ -53,14 +53,13 @@ use xtensa_lx_rt::entry;
 #[cfg(feature="riscv-rt")]
 use riscv_rt::entry;
 
-use embedded_graphics::{image::Image, pixelcolor::Rgb565};
-use tinybmp::Bmp;
+use embedded_graphics::{pixelcolor::Rgb565};
 // use esp32s2_hal::Rng;
 
 #[cfg(any(feature = "esp32s2_ili9341", feature = "esp32_wrover_kit", feature = "esp32c3_ili9341"))]
 use ili9341::{DisplaySize240x320, Ili9341, Orientation};
 
-use spooky_core::{assets::Assets, maze::Maze, spritebuf::SpriteBuf, engine::Engine};
+use spooky_core::{spritebuf::SpriteBuf, engine::Engine};
 
 #[cfg(any(feature = "imu_controls"))]
 use icm42670::{accelerometer::Accelerometer, Address, Icm42670};
@@ -95,19 +94,10 @@ impl <I:Accelerometer, D:embedded_graphics::draw_target::DrawTarget<Color = Rgb5
 
     pub fn render_frame(&mut self) -> &D {
 
-
-        #[cfg(any(feature = "imu_controls"))]
-        let accel_threshold = 0.20;
-
         #[cfg(any(feature = "imu_controls"))]
         {
+            let accel_threshold = 0.20;
             let accel_norm = self.icm.accel_norm().unwrap();
-            // let gyro_norm = self.icm.gyro_norm().unwrap();
-            // println!(
-            //     "ACCEL = X: {:+.04} Y: {:+.04} Z: {:+.04}; GYRO  = X: {:+.04} Y: {:+.04} Z: {:+.04}",
-            //     accel_norm.x, accel_norm.y, accel_norm.z,
-            //     gyro_norm.x, gyro_norm.y, gyro_norm.z
-            // );
 
             if accel_norm.y > accel_threshold {
                 self.engine.move_left();
@@ -128,10 +118,6 @@ impl <I:Accelerometer, D:embedded_graphics::draw_target::DrawTarget<Color = Rgb5
 
         self.engine.tick();
         self.engine.draw()
-
-
-        // display.flush().unwrap();
-        // &self.engine.display
 
     }
 

--- a/spooky-core/Cargo.toml
+++ b/spooky-core/Cargo.toml
@@ -11,7 +11,7 @@ rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 petgraph = { git = "https://github.com/zendurix/petgraph.git", branch = "better_no_std", default-features = false, features = ["graphmap"] }
 maze_generator = { git = "https://github.com/georgik/maze_generator", branch = "feature/no_std", default-features = false, features = [ "recursive_backtracking"] }
-
+heapless = { version = "0.7.14", default-features = false }
 
 [features]
 std = []

--- a/spooky-core/src/engine.rs
+++ b/spooky-core/src/engine.rs
@@ -171,7 +171,7 @@ impl <D:embedded_graphics::draw_target::DrawTarget<Color = Rgb565>> Engine <D> {
 
     }
 
-    pub fn draw(&mut self) -> &D {
+    pub fn draw(&mut self) -> &mut D {
         self.draw_maze(self.camera_x,self.camera_y);
 
 
@@ -283,7 +283,7 @@ impl <D:embedded_graphics::draw_target::DrawTarget<Color = Rgb565>> Engine <D> {
             .draw(&mut self.display)
             ;
 
-        &self.display
+        &mut self.display
     }
 
 

--- a/spooky-core/src/engine.rs
+++ b/spooky-core/src/engine.rs
@@ -1,7 +1,7 @@
 
 
 use embedded_graphics::{
-    prelude::{Point, DrawTarget, RgbColor},
+    prelude::{Point, RgbColor},
     mono_font::{
         ascii::{FONT_8X13},
         MonoTextStyle,
@@ -27,11 +27,7 @@ pub struct Engine<D> {
     maze: Maze,
     camera_x: i32,
     camera_y: i32,
-    // #[cfg(any(feature = "imu_controls"))]
-    // icm: I,
     animation_step: u32,
-    // icm: Option<Icm42670<shared_bus::I2cProxy<shared_bus::NullMutex<i2c::I2C<I2C0>>>>>
-    // delay: Some(Delay),
 }
 
 
@@ -178,53 +174,6 @@ impl <D:embedded_graphics::draw_target::DrawTarget<Color = Rgb565>> Engine <D> {
         match self.assets {
             Some(ref mut assets) => {
 
-                // #[cfg(any(feature = "button_controls"))]
-                // {
-                //     if button_down_pin.is_low().unwrap() {
-                //         if ghost_x > 0 {
-                //             if maze[(ghost_x/TILE_WIDTH)-1+ghost_y] == 0 {
-                //                 ghost_x -= TILE_WIDTH;
-                //             }
-                //         }
-                //     }
-
-                //     if button_up_pin.is_low().unwrap() {
-                //         if ghost_x < PLAYGROUND_WIDTH {
-                //             if maze[(ghost_x/TILE_WIDTH)+1+ghost_y] == 0 {
-                //                 ghost_x += TILE_WIDTH;
-                //             }
-                //         }
-                //     }
-
-                //     if button_menu_pin.is_low().unwrap() {
-                //         if ghost_y > 0 {
-                //             if maze[(ghost_x/TILE_WIDTH)+ghost_y-TILE_HEIGHT] == 0 {
-                //                 ghost_y -= TILE_HEIGHT;
-                //             }
-                //         }
-                //     }
-
-                //     if button_ok_pin.is_low().unwrap() {
-                //         if ghost_y < PLAYGROUND_HEIGHT {
-                //             if maze[(ghost_x/TILE_WIDTH)+ghost_y+TILE_HEIGHT] == 0 {
-                //                 ghost_y += TILE_HEIGHT;
-                //             }
-                //         }
-                //     }
-                // }
-
-                // if old_x != ghost_x || old_y != ghost_y {
-                //     let ground = Image::new(&ground_bmp, Point::new(old_x.try_into().unwrap(), old_y.try_into().unwrap()));
-
-                //     ground.draw(&mut display).unwrap();
-
-                //     let ghost2 = Image::new(&bmp, Point::new(ghost_x.try_into().unwrap(), ghost_y.try_into().unwrap()));
-
-                //     ghost2.draw(&mut display).unwrap();
-                //     old_x = ghost_x;
-                //     old_y = ghost_y;
-                // }
-
                 let coin_bmp:Bmp<Rgb565> = assets.coin.unwrap();
                 for index in 0..100 {
                     let coin = self.maze.coins[index];
@@ -280,8 +229,7 @@ impl <D:embedded_graphics::draw_target::DrawTarget<Color = Rgb565>> Engine <D> {
 
         let coin_message: String<5> = String::from(self.maze.coin_counter);
         Text::new(&coin_message, Point::new(10, 10), MonoTextStyle::new(&FONT_8X13, Rgb565::WHITE))
-            .draw(&mut self.display)
-            ;
+            .draw(&mut self.display);
 
         &mut self.display
     }

--- a/spooky-core/src/engine.rs
+++ b/spooky-core/src/engine.rs
@@ -1,0 +1,292 @@
+
+
+use embedded_graphics::{
+    prelude::{Point, DrawTarget, RgbColor},
+    mono_font::{
+        ascii::{FONT_8X13},
+        MonoTextStyle,
+    },
+    text::Text,
+    pixelcolor::Rgb565,
+    Drawable,
+    image::Image,
+};
+
+use crate::{assets::Assets, maze::Maze};
+use heapless::String;
+use tinybmp::Bmp;
+
+pub struct Engine<D> {
+    pub start_time: u64,
+    pub ghost_x: i32,
+    pub ghost_y: i32,
+    display: D,
+    assets: Option<Assets<'static>>,
+    step_size_x: u32,
+    step_size_y: u32,
+    maze: Maze,
+    camera_x: i32,
+    camera_y: i32,
+    // #[cfg(any(feature = "imu_controls"))]
+    // icm: I,
+    animation_step: u32,
+    // icm: Option<Icm42670<shared_bus::I2cProxy<shared_bus::NullMutex<i2c::I2C<I2C0>>>>>
+    // delay: Some(Delay),
+}
+
+
+impl <D:embedded_graphics::draw_target::DrawTarget<Color = Rgb565>> Engine <D> {
+    pub fn new(display:D, seed: Option<[u8; 32]>) -> Engine<D> {
+        Engine {
+            start_time: 0,
+            ghost_x: 9*16,
+            ghost_y: 7*16,
+            display,
+            assets: None,
+            step_size_x: 16,
+            step_size_y: 16,
+            maze: Maze::new(64, 64, seed),
+            camera_x: 0,
+            camera_y: 0,
+            // #[cfg(any(feature = "imu_controls"))]
+            animation_step: 0,
+            // delay: None,
+        }
+    }
+
+    fn check_coin_collision(&mut self) {
+        let x = self.camera_x + self.ghost_x;
+        let y = self.camera_y + self.ghost_y;
+
+        match self.maze.get_coin_at(x, y) {
+            Some(coin) => {
+                self.maze.remove_coin(coin);
+            },
+            None => {}
+        }
+    }
+
+    fn relocate_avatar(&mut self) {
+        let (new_camera_x, new_camera_y) = self.maze.get_random_coordinates();
+        (self.camera_x, self.camera_y) = (new_camera_x - self.ghost_x, new_camera_y - self.ghost_y);
+    }
+
+    fn check_npc_collision(&mut self) {
+        let x = self.camera_x + self.ghost_x;
+        let y = self.camera_y + self.ghost_y;
+
+        match self.maze.get_npc_at(x, y) {
+            Some(_npc) => {
+                self.relocate_avatar();
+            },
+            None => {}
+        }
+    }
+
+    pub fn move_right(&mut self) {
+        let new_camera_x = self.camera_x + self.step_size_x as i32;
+        if !self.maze.check_wall_collision(new_camera_x + self.ghost_x, self.camera_y + self.ghost_y) {
+            self.camera_x = new_camera_x;
+            self.check_coin_collision();
+        }
+    }
+
+    pub fn move_left(&mut self) {
+        let new_camera_x = self.camera_x - self.step_size_x as i32;
+        if !self.maze.check_wall_collision(new_camera_x + self.ghost_x, self.camera_y + self.ghost_y) {
+            self.camera_x = new_camera_x;
+            self.check_coin_collision();
+        }
+    }
+
+    pub fn move_up(&mut self) {
+        let new_camera_y = self.camera_y - self.step_size_y as i32;
+        if !self.maze.check_wall_collision(self.camera_x + self.ghost_x, new_camera_y + self.ghost_y) {
+            self.camera_y = new_camera_y;
+            self.check_coin_collision();
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        let new_camera_y = self.camera_y + self.step_size_y as i32;
+        if !self.maze.check_wall_collision(self.camera_x + self.ghost_x, new_camera_y + self.ghost_y) {
+            self.camera_y = new_camera_y;
+            self.check_coin_collision();
+        }
+    }
+
+
+    pub fn draw_maze(&mut self, camera_x: i32, camera_y: i32) {
+        #[cfg(feature = "system_timer")]
+        let start_timestamp = SystemTimer::now();
+
+        let assets = self.assets.as_ref().unwrap();
+        let ground = assets.ground.as_ref().unwrap();
+        let wall = assets.wall.as_ref().unwrap();
+        let empty = assets.empty.as_ref().unwrap();
+
+        let camera_tile_x = camera_x / self.maze.tile_width as i32;
+        let camera_tile_y = camera_y / self.maze.tile_height as i32;
+        for x in camera_tile_x..(camera_tile_x + (self.maze.visible_width as i32)-1) {
+            for y in camera_tile_y..(camera_tile_y + (self.maze.visible_height as i32)-1) {
+                let position_x = (x as i32 * self.maze.tile_width as i32) - camera_x;
+                let position_y = (y as i32 * self.maze.tile_height as i32) - camera_y;
+                let position = Point::new(position_x, position_y);
+
+                if x < 0 || y < 0 || x > (self.maze.width-1) as i32 || y > (self.maze.height-1) as i32 {
+                    let tile = Image::new(empty, position);
+                    tile.draw(&mut self.display);
+                } else if self.maze.data[(x+y*(self.maze.width as i32)) as usize] == 0 {
+                    let tile = Image::new(ground, position);
+                    tile.draw(&mut self.display);
+                } else {
+                    let tile = Image::new(wall, position);
+                    tile.draw(&mut self.display);
+                }
+            }
+        }
+    }
+
+
+    pub fn tick(&mut self) {
+        self.animation_step += 1;
+        if self.animation_step > 1 {
+            self.animation_step = 0;
+        }
+
+        self.maze.move_npcs();
+        self.check_npc_collision();
+    }
+
+    pub fn initialize(&mut self) {
+        let mut assets = Assets::new();
+        assets.load();
+        self.assets = Some(assets);
+
+        self.maze.generate_maze(32, 32);
+        self.relocate_avatar();
+        self.maze.generate_coins();
+        self.maze.generate_npcs();
+        self.draw_maze(self.camera_x,self.camera_y);
+
+    }
+
+    pub fn draw(&mut self) -> &D {
+        self.draw_maze(self.camera_x,self.camera_y);
+
+
+        match self.assets {
+            Some(ref mut assets) => {
+
+                // #[cfg(any(feature = "button_controls"))]
+                // {
+                //     if button_down_pin.is_low().unwrap() {
+                //         if ghost_x > 0 {
+                //             if maze[(ghost_x/TILE_WIDTH)-1+ghost_y] == 0 {
+                //                 ghost_x -= TILE_WIDTH;
+                //             }
+                //         }
+                //     }
+
+                //     if button_up_pin.is_low().unwrap() {
+                //         if ghost_x < PLAYGROUND_WIDTH {
+                //             if maze[(ghost_x/TILE_WIDTH)+1+ghost_y] == 0 {
+                //                 ghost_x += TILE_WIDTH;
+                //             }
+                //         }
+                //     }
+
+                //     if button_menu_pin.is_low().unwrap() {
+                //         if ghost_y > 0 {
+                //             if maze[(ghost_x/TILE_WIDTH)+ghost_y-TILE_HEIGHT] == 0 {
+                //                 ghost_y -= TILE_HEIGHT;
+                //             }
+                //         }
+                //     }
+
+                //     if button_ok_pin.is_low().unwrap() {
+                //         if ghost_y < PLAYGROUND_HEIGHT {
+                //             if maze[(ghost_x/TILE_WIDTH)+ghost_y+TILE_HEIGHT] == 0 {
+                //                 ghost_y += TILE_HEIGHT;
+                //             }
+                //         }
+                //     }
+                // }
+
+                // if old_x != ghost_x || old_y != ghost_y {
+                //     let ground = Image::new(&ground_bmp, Point::new(old_x.try_into().unwrap(), old_y.try_into().unwrap()));
+
+                //     ground.draw(&mut display).unwrap();
+
+                //     let ghost2 = Image::new(&bmp, Point::new(ghost_x.try_into().unwrap(), ghost_y.try_into().unwrap()));
+
+                //     ghost2.draw(&mut display).unwrap();
+                //     old_x = ghost_x;
+                //     old_y = ghost_y;
+                // }
+
+                let coin_bmp:Bmp<Rgb565> = assets.coin.unwrap();
+                for index in 0..100 {
+                    let coin = self.maze.coins[index];
+                    if coin.x < 0 || coin.y < 0 {
+                        continue;
+                    }
+
+                    let draw_x = coin.x - self.camera_x;
+                    let draw_y = coin.y - self.camera_y;
+                    if draw_x >= 0 && draw_y >= 0 && draw_x < (self.maze.visible_width*16).try_into().unwrap() && draw_y < (self.maze.visible_height*16).try_into().unwrap() {
+                        let position = Point::new(draw_x, draw_y);
+                        let tile = Image::new(&coin_bmp, position);
+                        tile.draw(&mut self.display);
+                    }
+                }
+
+                let npc_bmp:Bmp<Rgb565> = assets.npc.unwrap();
+                for index in 0..5 {
+                    let item = self.maze.npcs[index];
+                    if item.x < 0 || item.y < 0 {
+                        continue;
+                    }
+
+                    let draw_x = item.x - self.camera_x;
+                    let draw_y = item.y - self.camera_y;
+                    if draw_x >= 0 && draw_y >= 0 && draw_x < (self.maze.visible_width*16).try_into().unwrap() && draw_y < (self.maze.visible_height*16).try_into().unwrap() {
+                        let position = Point::new(draw_x, draw_y);
+                        let tile = Image::new(&npc_bmp, position);
+                        tile.draw(&mut self.display);
+                    }
+                }
+
+                match self.animation_step {
+                    0 => {
+                        let bmp:Bmp<Rgb565> = assets.ghost1.unwrap();
+                        let ghost1 = Image::new(&bmp, Point::new(self.ghost_x.try_into().unwrap(), self.ghost_y.try_into().unwrap()));
+                        ghost1.draw(&mut self.display);
+                    },
+                    _ => {
+                        let bmp:Bmp<Rgb565> = assets.ghost2.unwrap();
+                        let ghost2 = Image::new(&bmp, Point::new(self.ghost_x.try_into().unwrap(), self.ghost_y.try_into().unwrap()));
+                        ghost2.draw(&mut self.display);
+                    },
+
+                }
+                // display.flush().unwrap();
+            },
+            None => {
+                panic!("Assets not loaded");
+            }
+        };
+
+
+        let coin_message: String<5> = String::from(self.maze.coin_counter);
+        Text::new(&coin_message, Point::new(10, 10), MonoTextStyle::new(&FONT_8X13, Rgb565::WHITE))
+            .draw(&mut self.display)
+            ;
+
+        &self.display
+    }
+
+
+}
+
+

--- a/spooky-core/src/lib.rs
+++ b/spooky-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 pub mod assets;
+pub mod engine;
 pub mod maze;
 pub mod spritebuf;

--- a/spooky-core/src/maze.rs
+++ b/spooky-core/src/maze.rs
@@ -162,7 +162,7 @@ impl Maze {
     pub fn generate_maze(&mut self, graph_width: usize, graph_height: usize) {
         // let mut rng = Rng::new(peripherals.RNG);
         // let mut rng = Rng::new( 0x12345678 );
-        let mut seed_buffer = [0u8;32];
+        let seed_buffer = [0u8;32];
         // match &self.rng {
         //     Some(rng) => rng.fill_bytes(&mut seed_buffer),
         //     None => {}

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -20,8 +20,8 @@ embedded-graphics = "0.7"
 wasm-bindgen = "0.2.83"
 web-sys = { version = "0.3.60", features = ['Window', 'Performance', 'PerformanceTiming']}
 embedded-graphics-framebuf = "0.2.0"
-# embedded-graphics-web-simulator = { git = "https://github.com/georgik/embedded-graphics-web-simulator.git", branch = "feature/sprite" }
-embedded-graphics-web-simulator = "0.3.0"
+embedded-graphics-web-simulator = { git = "https://github.com/georgik/embedded-graphics-web-simulator.git", branch = "feature/sprite" }
+# embedded-graphics-web-simulator = "0.3.0"
 # rand = { version = "0.8.5", default-features = false }
 getrandom = { version = "0.2.8", features = ["js"] }
 rand_chacha = { version = "0.3.1", default-features = false }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -19,8 +19,9 @@ embedded-graphics = "0.7"
 # display-interface-spi = "0.4"
 wasm-bindgen = "0.2.83"
 web-sys = { version = "0.3.60", features = ['Window', 'Performance', 'PerformanceTiming']}
-embedded-graphics-web-simulator = { git = "https://github.com/georgik/embedded-graphics-web-simulator.git", branch = "feature/sprite" }
-# embedded-graphics-web-simulator = { path = "../../embedded-graphics-web-simulator" }
+embedded-graphics-framebuf = "0.2.0"
+# embedded-graphics-web-simulator = { git = "https://github.com/georgik/embedded-graphics-web-simulator.git", branch = "feature/sprite" }
+embedded-graphics-web-simulator = "0.3.0"
 # rand = { version = "0.8.5", default-features = false }
 getrandom = { version = "0.2.8", features = ["js"] }
 rand_chacha = { version = "0.3.1", default-features = false }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -32,7 +32,7 @@ use heapless::String;
 
 #[wasm_bindgen]
 pub struct Universe {
-    display: WebSimulatorDisplay<Rgb565>,
+    engine: Engine<WebSimulatorDisplay<Rgb565>>,
 }
 
 fn get_seed_buffer() -> Option<[u8; 32]> {
@@ -47,59 +47,51 @@ impl Universe {
 
     pub fn new() -> Universe {
         Universe {
-            display: {
+            engine: {
                 let document = web_sys::window().unwrap().document().unwrap();
                 let output_settings = OutputSettingsBuilder::new()
                     .scale(1)
                     .pixel_spacing(1)
                     .build();
-                WebSimulatorDisplay::new(
+                let display = WebSimulatorDisplay::new(
                         (320, 240),
                         &output_settings,
                         document.get_element_by_id("graphics").as_ref(),
-                )
+                );
+                // let mut data = [Rgb565::BLACK ; 320*240];
+                // let fbuf = FrameBuf::new(&mut data, 320, 240);
+                // let spritebuf = SpriteBuf::new(fbuf);
+                Engine::new(display, get_seed_buffer())
             }
         }
     }
 
+    pub fn move_up(&mut self) {
+        self.engine.move_up();
+    }
+
+    pub fn move_down(&mut self) {
+        self.engine.move_down();
+    }
+
+    pub fn move_left(&mut self) {
+        self.engine.move_left();
+    }
+
+    pub fn move_right(&mut self) {
+        self.engine.move_right();
+    }
 
     pub fn initialize(&mut self) {
-        
-        
-        display.clear(Rgb565::BLACK).unwrap();
-        display.flush().unwrap();
-        // display = Some(display);
-        let mut data = [Rgb565::BLACK ; 320*240];
-        let fbuf = FrameBuf::new(&mut data, 320, 240);
-        let spritebuf = SpriteBuf::new(fbuf);
-        unsafe {
-        engine = Engine::new(spritebuf, get_seed_buffer());
-        engine.initialize();
-        }
-        // self.engine = Some(engine);
-
+        self.engine.initialize();
     }
 
     pub fn render_frame(&mut self) {
 
         console::log_1(&"tick".into());
-
-        // match &mut self.engine {
-        //     Some(engine) => {
-        //         engine.tick();
-        //         let buf = engine.draw();
-        //         match self.display {
-        //             Some(ref mut display) => {
-        //                 display.draw_iter(buf.into_iter()).unwrap();
-        //             },
-        //             None => {},
-        //         }
-        //         // display.flush().unwrap();
-        //     },
-        //     None => {
-        //         console::log_1(&"no engine".into());
-        //     }
-        // }
+        self.engine.tick();
+        let display:&mut WebSimulatorDisplay<Rgb565> = self.engine.draw();
+        display.flush().unwrap();
 
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -32,8 +32,7 @@ use heapless::String;
 
 #[wasm_bindgen]
 pub struct Universe {
-    engine: Option<Engine<SpriteBuf<FrameBufferBackend<Color = Rgb565>>>>,
-    display: Option<WebSimulatorDisplay<Rgb565>>,
+
 }
 
 fn get_seed_buffer() -> Option<[u8; 32]> {
@@ -47,8 +46,6 @@ impl Universe {
 
     pub fn new() -> Universe {
         Universe {
-            engine: Engine,
-            display: None,
         }
     }
 
@@ -68,13 +65,13 @@ impl Universe {
 
         display.clear(Rgb565::BLACK).unwrap();
         display.flush().unwrap();
-        self.display = Some(display);
+        // display = Some(display);
         let mut data = [Rgb565::BLACK ; 320*240];
         let fbuf = FrameBuf::new(&mut data, 320, 240);
         let spritebuf = SpriteBuf::new(fbuf);
         let mut engine = Engine::new(spritebuf, get_seed_buffer());
         engine.initialize();
-        self.engine = Some(engine);
+        // self.engine = Some(engine);
 
     }
 
@@ -82,22 +79,22 @@ impl Universe {
 
         console::log_1(&"tick".into());
 
-        match &mut self.engine {
-            Some(engine) => {
-                engine.tick();
-                let buf = engine.draw();
-                match self.display {
-                    Some(ref mut display) => {
-                        display.draw_iter(buf.into_iter()).unwrap();
-                    },
-                    None => {},
-                }
-                // display.flush().unwrap();
-            },
-            None => {
-                console::log_1(&"no engine".into());
-            }
-        }
+        // match &mut self.engine {
+        //     Some(engine) => {
+        //         engine.tick();
+        //         let buf = engine.draw();
+        //         match self.display {
+        //             Some(ref mut display) => {
+        //                 display.draw_iter(buf.into_iter()).unwrap();
+        //             },
+        //             None => {},
+        //         }
+        //         // display.flush().unwrap();
+        //     },
+        //     None => {
+        //         console::log_1(&"no engine".into());
+        //     }
+        // }
 
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -32,7 +32,7 @@ use heapless::String;
 
 #[wasm_bindgen]
 pub struct Universe {
-
+    display: WebSimulatorDisplay<Rgb565>,
 }
 
 fn get_seed_buffer() -> Option<[u8; 32]> {
@@ -41,36 +41,41 @@ fn get_seed_buffer() -> Option<[u8; 32]> {
     Some(seed_buffer)
 }
 
+
 #[wasm_bindgen]
 impl Universe {
 
     pub fn new() -> Universe {
         Universe {
+            display: {
+                let document = web_sys::window().unwrap().document().unwrap();
+                let output_settings = OutputSettingsBuilder::new()
+                    .scale(1)
+                    .pixel_spacing(1)
+                    .build();
+                WebSimulatorDisplay::new(
+                        (320, 240),
+                        &output_settings,
+                        document.get_element_by_id("graphics").as_ref(),
+                )
+            }
         }
     }
 
 
     pub fn initialize(&mut self) {
         
-        let document = web_sys::window().unwrap().document().unwrap();
-        let output_settings = OutputSettingsBuilder::new()
-            .scale(1)
-            .pixel_spacing(1)
-            .build();
-        let mut display = WebSimulatorDisplay::new(
-                (320, 240),
-                &output_settings,
-                document.get_element_by_id("graphics").as_ref(),
-        );
-
+        
         display.clear(Rgb565::BLACK).unwrap();
         display.flush().unwrap();
         // display = Some(display);
         let mut data = [Rgb565::BLACK ; 320*240];
         let fbuf = FrameBuf::new(&mut data, 320, 240);
         let spritebuf = SpriteBuf::new(fbuf);
-        let mut engine = Engine::new(spritebuf, get_seed_buffer());
+        unsafe {
+        engine = Engine::new(spritebuf, get_seed_buffer());
         engine.initialize();
+        }
         // self.engine = Some(engine);
 
     }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -24,24 +24,16 @@ use embedded_graphics::{
     Drawable,
 };
 
-use spooky_core::assets::Assets;
-use spooky_core::maze::Maze;
+use spooky_core::{ assets::Assets, maze::Maze, engine::Engine, spritebuf::SpriteBuf };
+use embedded_graphics_framebuf::{FrameBuf, backends::FrameBufferBackend};
 
 use tinybmp::Bmp;
 use heapless::String;
 
 #[wasm_bindgen]
 pub struct Universe {
-    pub start_time: u64,
-    pub ghost_x: i32,
-    pub ghost_y: i32,
+    engine: Option<Engine<SpriteBuf<FrameBufferBackend<Color = Rgb565>>>>,
     display: Option<WebSimulatorDisplay<Rgb565>>,
-    assets: Option<Assets<'static>>,
-    step_size_x: u32,
-    step_size_y: u32,
-    maze: Maze,
-    camera_x: i32,
-    camera_y: i32,
 }
 
 fn get_seed_buffer() -> Option<[u8; 32]> {
@@ -52,158 +44,37 @@ fn get_seed_buffer() -> Option<[u8; 32]> {
 
 #[wasm_bindgen]
 impl Universe {
+
     pub fn new() -> Universe {
         Universe {
-            start_time: 0,
-            ghost_x: 9*16,
-            ghost_y: 7*16,
+            engine: Engine,
             display: None,
-            assets: None,
-            step_size_x: 16,
-            step_size_y: 16,
-            maze: Maze::new(64, 64, get_seed_buffer()),
-            camera_x: 0,
-            camera_y: 0,
         }
-    }
-
-    fn check_coin_collision(&mut self) {
-        let x = self.camera_x + self.ghost_x;
-        let y = self.camera_y + self.ghost_y;
-
-        match self.maze.get_coin_at(x, y) {
-            Some(coin) => {
-                self.maze.remove_coin(coin);
-            },
-            None => {}
-        }
-    }
-
-    fn relocate_avatar(&mut self) {
-        let (new_camera_x, new_camera_y) = self.maze.get_random_coordinates();
-        (self.camera_x, self.camera_y) = (new_camera_x - self.ghost_x, new_camera_y - self.ghost_y);
-    }
-
-    fn check_npc_collision(&mut self) {
-        let x = self.camera_x + self.ghost_x;
-        let y = self.camera_y + self.ghost_y;
-
-        match self.maze.get_npc_at(x, y) {
-            Some(_npc) => {
-                self.relocate_avatar();
-            },
-            None => {}
-        }
-    }
-
-    pub fn move_right(&mut self) {
-        let new_camera_x = self.camera_x + self.step_size_x as i32;
-        if !self.maze.check_wall_collision(new_camera_x + self.ghost_x, self.camera_y + self.ghost_y) {
-            self.camera_x = new_camera_x;
-            self.check_coin_collision();
-        }
-        console::log_1(&"key_right".into());
-    }
-
-    pub fn move_left(&mut self) {
-        let new_camera_x = self.camera_x - self.step_size_x as i32;
-        if !self.maze.check_wall_collision(new_camera_x + self.ghost_x, self.camera_y + self.ghost_y) {
-            self.camera_x = new_camera_x;
-            self.check_coin_collision();
-        }
-        console::log_1(&"key_left".into());
-    }
-
-    pub fn move_up(&mut self) {
-        let new_camera_y = self.camera_y - self.step_size_y as i32;
-        if !self.maze.check_wall_collision(self.camera_x + self.ghost_x, new_camera_y + self.ghost_y) {
-            self.camera_y = new_camera_y;
-            self.check_coin_collision();
-        }
-        console::log_1(&"key_up".into());
-    }
-
-    pub fn move_down(&mut self) {
-        let new_camera_y = self.camera_y + self.step_size_y as i32;
-        if !self.maze.check_wall_collision(self.camera_x + self.ghost_x, new_camera_y + self.ghost_y) {
-            self.camera_y = new_camera_y;
-            self.check_coin_collision();
-        }
-        console::log_1(&"key_down".into());
-    }
-
-    pub fn draw_maze(&mut self, camera_x: i32, camera_y: i32) {
-        println!("Rendering the maze to display");
-        #[cfg(feature = "system_timer")]
-        let start_timestamp = SystemTimer::now();
-
-
-        match self.display {
-            Some(ref mut display) => {
-                let assets = self.assets.as_ref().unwrap();
-                let ground = assets.ground.as_ref().unwrap();
-                let wall = assets.wall.as_ref().unwrap();
-                let empty = assets.empty.as_ref().unwrap();
-
-                let camera_tile_x = camera_x / self.maze.tile_width as i32;
-                let camera_tile_y = camera_y / self.maze.tile_height as i32;
-                for x in camera_tile_x..(camera_tile_x + (self.maze.visible_width as i32)-1) {
-                    for y in camera_tile_y..(camera_tile_y + (self.maze.visible_height as i32)-1) {
-                        let position_x = (x as i32 * self.maze.tile_width as i32) - camera_x;
-                        let position_y = (y as i32 * self.maze.tile_height as i32) - camera_y;
-                        let position = Point::new(position_x, position_y);
-
-                        if x < 0 || y < 0 || x > (self.maze.width-1) as i32 || y > (self.maze.height-1) as i32 {
-                            let tile = Image::new(empty, position);
-                            tile.draw(display).unwrap();
-                        } else if self.maze.data[(x+y*(self.maze.width as i32)) as usize] == 0 {
-                            let tile = Image::new(ground, position);
-                            tile.draw(display).unwrap();
-                        } else {
-                            let tile = Image::new(wall, position);
-                            tile.draw(display).unwrap();
-                        }
-                    }
-                }
-            },
-            None => {}
-        }
-
-
     }
 
 
     pub fn initialize(&mut self) {
+        
         let document = web_sys::window().unwrap().document().unwrap();
         let output_settings = OutputSettingsBuilder::new()
             .scale(1)
             .pixel_spacing(1)
             .build();
-        self.display = Some(WebSimulatorDisplay::new(
+        let mut display = WebSimulatorDisplay::new(
                 (320, 240),
                 &output_settings,
                 document.get_element_by_id("graphics").as_ref(),
-        ));
+        );
 
-        match self.display {
-            Some(ref mut display) => {
-                display.clear(Rgb565::BLACK).unwrap();
-                display.flush().unwrap();
-            },
-            None => {}
-        }
-
-        println!("Loading image");
-
-        let mut assets = Assets::new();
-        assets.load();
-        self.assets = Some(assets);
-
-        self.maze.generate_maze(32, 32);
-        self.relocate_avatar();
-        self.maze.generate_coins();
-        self.maze.generate_npcs();
-        self.draw_maze(self.camera_x,self.camera_y);
+        display.clear(Rgb565::BLACK).unwrap();
+        display.flush().unwrap();
+        self.display = Some(display);
+        let mut data = [Rgb565::BLACK ; 320*240];
+        let fbuf = FrameBuf::new(&mut data, 320, 240);
+        let spritebuf = SpriteBuf::new(fbuf);
+        let mut engine = Engine::new(spritebuf, get_seed_buffer());
+        engine.initialize();
+        self.engine = Some(engine);
 
     }
 
@@ -211,63 +82,21 @@ impl Universe {
 
         console::log_1(&"tick".into());
 
-        self.maze.move_npcs();
-        self.check_npc_collision();
-        self.draw_maze(self.camera_x,self.camera_y);
-
-        match self.display {
-            Some(ref mut display) => {
-                match self.assets {
-                    Some(ref mut assets) => {
-
-                        let coin_bmp:Bmp<Rgb565> = assets.coin.unwrap();
-                        for index in 0..100 {
-                            let coin = self.maze.coins[index];
-                            if coin.x < 0 || coin.y < 0 {
-                                continue;
-                            }
-
-                            let draw_x = coin.x - self.camera_x;
-                            let draw_y = coin.y - self.camera_y;
-                            if draw_x >= 0 && draw_y >= 0 && draw_x < (self.maze.visible_width*16).try_into().unwrap() && draw_y < (self.maze.visible_height*16).try_into().unwrap() {
-                                let position = Point::new(draw_x, draw_y);
-                                let tile = Image::new(&coin_bmp, position);
-                                tile.draw(display).unwrap();
-                            }
-                        }
-
-                        let npc_bmp:Bmp<Rgb565> = assets.npc.unwrap();
-                        for index in 0..5 {
-                            let item = self.maze.npcs[index];
-                            if item.x < 0 || item.y < 0 {
-                                continue;
-                            }
-
-                            let draw_x = item.x - self.camera_x;
-                            let draw_y = item.y - self.camera_y;
-                            if draw_x >= 0 && draw_y >= 0 && draw_x < (self.maze.visible_width*16).try_into().unwrap() && draw_y < (self.maze.visible_height*16).try_into().unwrap() {
-                                let position = Point::new(draw_x, draw_y);
-                                let tile = Image::new(&npc_bmp, position);
-                                tile.draw(display).unwrap();
-                            }
-                        }
-
-                        let bmp:Bmp<Rgb565> = assets.ghost1.unwrap();
-                        let ghost1 = Image::new(&bmp, Point::new(self.ghost_x.try_into().unwrap(), self.ghost_y.try_into().unwrap()));
-                        ghost1.draw(display).unwrap();
-                        display.flush().unwrap();
+        match &mut self.engine {
+            Some(engine) => {
+                engine.tick();
+                let buf = engine.draw();
+                match self.display {
+                    Some(ref mut display) => {
+                        display.draw_iter(buf.into_iter()).unwrap();
                     },
-                    None => {}
+                    None => {},
                 }
-
-                let coin_message: String<5> = String::from(self.maze.coin_counter);
-                Text::new(&coin_message, Point::new(10, 10), MonoTextStyle::new(&FONT_8X13, Rgb565::WHITE))
-                    .draw(display)
-                    .unwrap();
-
-                display.flush().unwrap();
+                // display.flush().unwrap();
             },
-            None => {}
+            None => {
+                console::log_1(&"no engine".into());
+            }
         }
 
     }


### PR DESCRIPTION
Move generic logic to engine layer.
Solve the problem with passing display reference to lower layer.
Note: WASM does not support bindgen for generic types.