### PR TITLE
add MPU6886 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,14 @@ cargo build --release --no-default-features --features "wokwi"
 
 Press F1, select Wokwi: Start simulation
 
-### Build for M5Stack-Core2 with ESP32 and ILI9341
+### Build for M5Stack-Core2 with ESP32 and ILI9342C
 
 HW: https://shop.m5stack.com/products/m5stack-core2-esp32-iot-development-kit?variant=35960244109476
 
-Control: TBD
+Control: MPU6886
+- tilt the board to move the character
+- move quickly up or press button C to teleport
+- move quickly down or press button B to place dynamite and destroy walls around
 
 ```
 cd m5stack-core2

--- a/m5stack-core2/Cargo.toml
+++ b/m5stack-core2/Cargo.toml
@@ -24,6 +24,7 @@ mpu9250 = { version = "0.24.1", default-features = false, features = [
     "i2c",
 ], optional = true }
 mpu6050 = { version = "0.1.6", optional = true }
+mpu6886 = { version = "0.1.0", optional = true }
 mipidsi = { git = "https://github.com/rfuest/mipidsi.git", branch = "display-driver-hal" }
 panic-halt = "0.2"
 shared-bus = { version = "0.2.4" }
@@ -46,8 +47,9 @@ esp32s3 = []
 esp32c3 = ["system_timer"]
 
 mpu6050 = ["imu_controls", "dep:mpu6050"]
+mpu6886 = ["imu_controls", "dep:mpu6886"]
 mpu9250 = ["imu_controls", "dep:mpu9250"]
 
 wokwi = [ "xtensa-lx-rt", "esp32", "esp32-hal/eh1", "mpu6050" ]
 
-m5stack_core2 = ["xtensa-lx-rt", "esp32", "esp32-hal/eh1", ]
+m5stack_core2 = ["xtensa-lx-rt", "esp32", "esp32-hal/eh1", "mpu6886" ]

--- a/m5stack-core2/src/main.rs
+++ b/m5stack-core2/src/main.rs
@@ -43,6 +43,9 @@ use mpu9250::{ImuMeasurements, Mpu9250};
 #[cfg(feature = "mpu6050")]
 use mpu6050::Mpu6050;
 
+#[cfg(feature = "mpu6886")]
+use mpu6886::Mpu6886;
+
 #[cfg(feature = "xtensa-lx-rt")]
 use xtensa_lx_rt::entry;
 
@@ -129,8 +132,9 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
+    // M5Stack CORE 2 - https://docs.m5stack.com/en/core/core2
     #[cfg(feature = "esp32")]
-    let mut backlight = io.pins.gpio32.into_push_pull_output();
+    let mut backlight = io.pins.gpio3.into_push_pull_output();
 
     #[cfg(feature = "esp32")]
     let spi = spi::Spi::new(
@@ -151,7 +155,7 @@ fn main() -> ! {
     let di = SPIInterfaceNoCS::new(spi, io.pins.gpio15.into_push_pull_output());
 
     #[cfg(feature = "m5stack_core2")]
-    let mut display = mipidsi::Builder::ili9341_rgb565(di)
+    let mut display = mipidsi::Builder::ili9342c_rgb565(di)
         .with_display_size(320, 240)
         .init(&mut delay, Some(reset))
         .unwrap();
@@ -204,7 +208,11 @@ fn main() -> ! {
 
     #[cfg(any(feature = "mpu6050"))]
     let mut icm = Mpu6050::new(bus.acquire_i2c());
-    #[cfg(any(feature = "mpu6050"))]
+
+    #[cfg(any(feature = "mpu6886"))]
+    let mut icm = Mpu6886::new(bus.acquire_i2c());
+
+    #[cfg(any(feature = "mpu6050", feature = "mpu6886"))]
     icm.init(&mut delay).unwrap();
 
     let mut rng = Rng::new(peripherals.RNG);
@@ -272,9 +280,14 @@ fn main() -> ! {
             }
         }
 
-        #[cfg(feature = "mpu6050")]
+        #[cfg(any(feature = "mpu6050", feature = "mpu6886"))]
         {
+            #[cfg(feature = "mpu6050")]
             let accel_threshold = 1.00;
+
+            #[cfg(feature = "mpu6886")]
+            let accel_threshold = 0.30;
+
             let measurement = icm.get_acc().unwrap();
             // let measurement: ImuMeasurements<[f32; 3]> = icm.all().unwrap();
 


### PR DESCRIPTION
Add support of MPU6886 to M5Stack Core2 based.
Driver mentioned: https://github.com/georgik/esp32-rust-multi-target-template/issues/1
Fixed display support.