### PR TITLE
Update hal 2023-03

### DIFF
--- a/esp-wrover-kit/Cargo.toml
+++ b/esp-wrover-kit/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 
 [target.xtensa-esp32-none-elf.dependencies]
 xtensa-atomic-emulation-trap = "0.4.0"
-esp32-hal = "0.8.0"
-esp-backtrace = { version = "0.5.0", features = [
+esp32-hal = "0.10.0"
+esp-backtrace = { version = "0.6.0", features = [
     "esp32",
     "panic-handler",
     "print-uart",

--- a/esp32-c3-devkit-rust/Cargo.toml
+++ b/esp32-c3-devkit-rust/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT"
 
 [target.riscv32imac-unknown-none-elf.dependencies]
 esp32c3-hal = "0.7.0"
-esp-backtrace = { version = "0.5.0", features = [
+esp-backtrace = { version = "0.6.0", features = [
     "esp32c3",
     "panic-handler",
     "print-uart",
 ] }
-esp-println = { version = "0.3.1", features = [ "esp32c3" ] }
+esp-println = { version = "0.4.0", features = [ "esp32c3" ] }
 
 [dependencies]
 esp-alloc = "0.2.0"

--- a/esp32-c6-devkit/Cargo.toml
+++ b/esp32-c6-devkit/Cargo.toml
@@ -7,16 +7,15 @@ license = "MIT"
 
 [target.riscv32imac-unknown-none-elf.dependencies]
 esp32c6-hal = { version = "*", git = "https://github.com/jessebraham/esp-hal.git", branch = "feature/esp32c6" }
-esp-backtrace = { version = "0.5.0", features = [
+esp-backtrace = { version = "0.6.0", features = [
     "esp32c3",
     "panic-handler",
     "print-uart",
 ] }
-riscv-rt = { version = "0.11", optional = true }
-esp-println = { version = "0.3.1", features = [ "esp32c3" ] }
+esp-println = { version = "0.4.0", features = [ "esp32c3" ] }
 
 [dependencies]
-esp-alloc = "0.1.0"
+esp-alloc = "0.2.0"
 embedded-graphics = "0.7"
 embedded-hal = "0.2"
 display-interface = "0.4"
@@ -44,4 +43,4 @@ imu_controls = []
 
 esp32c6 = ["system_timer"]
 
-esp32c6_ili9341 = [ "riscv-rt", "esp32c6", "esp32c6-hal/eh1" ]
+esp32c6_ili9341 = [ "esp32c6", "esp32c6-hal/eh1" ]

--- a/esp32-s2-kaluga/Cargo.toml
+++ b/esp32-s2-kaluga/Cargo.toml
@@ -7,17 +7,17 @@ license = "MIT"
 
 [target.xtensa-esp32s2-none-elf.dependencies]
 xtensa-atomic-emulation-trap = "0.4.0"
-esp32s2-hal = "0.5.0"
-esp-backtrace = { version = "0.5.0", features = [
+esp32s2-hal = "0.7.0"
+esp-backtrace = { version = "0.6.0", features = [
     "esp32s2",
     "panic-handler",
     "print-uart",
 ] }
 xtensa-lx-rt = { version = "0.15.0", features = ["esp32s2"], optional = true }
-esp-println = { version = "0.3.1", features = ["esp32s2"] }
+esp-println = { version = "0.4.0", features = ["esp32s2"] }
 
 [dependencies]
-esp-alloc = "0.1.0"
+esp-alloc = "0.2.0"
 embedded-graphics = "0.7"
 embedded-hal = "0.2"
 display-interface = "0.4"

--- a/esp32-s2-usb-otg/Cargo.toml
+++ b/esp32-s2-usb-otg/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 
 [target.xtensa-esp32s2-none-elf.dependencies]
 xtensa-atomic-emulation-trap = "0.4.0"
-esp32s2-hal = "0.5.0"
-esp-backtrace = { version = "0.5.0", features = [
+esp32s2-hal = "0.7.0"
+esp-backtrace = { version = "0.6.0", features = [
     "esp32s2",
     "panic-handler",
     "print-uart",
@@ -17,7 +17,7 @@ xtensa-lx-rt = { version = "0.15.0", features = ["esp32s2"], optional = true }
 esp-println = { version = "0.3.1", features = ["esp32s2"] }
 
 [dependencies]
-esp-alloc = "0.1.0"
+esp-alloc = "0.2.0"
 embedded-graphics = "0.7"
 embedded-hal = "0.2"
 display-interface = "0.4"

--- a/esp32-s3-box/Cargo.toml
+++ b/esp32-s3-box/Cargo.toml
@@ -7,17 +7,17 @@ license = "MIT"
 
 [target.xtensa-esp32s3-none-elf.dependencies]
 xtensa-atomic-emulation-trap = "0.4.0"
-esp32s3-hal = "0.5.0"
-esp-backtrace = { version = "0.5.0", features = [
+esp32s3-hal = "0.7.0"
+esp-backtrace = { version = "0.6.0", features = [
     "esp32s3",
     "panic-handler",
     "print-uart",
 ] }
 xtensa-lx-rt = { version = "0.15.0", features = ["esp32s3"], optional = true }
-esp-println = { version = "0.3.1", features = ["esp32s3"] }
+esp-println = { version = "0.4.0", features = ["esp32s3"] }
 
 [dependencies]
-esp-alloc = "0.1.0"
+esp-alloc = "0.2.0"
 embedded-graphics = "0.7"
 embedded-hal = "0.2"
 display-interface = "0.4"

--- a/esp32-s3-usb-otg/Cargo.toml
+++ b/esp32-s3-usb-otg/Cargo.toml
@@ -7,18 +7,18 @@ license = "MIT"
 
 [target.xtensa-esp32s3-none-elf.dependencies]
 xtensa-atomic-emulation-trap = "0.4.0"
-esp32s3-hal = "0.5.0"
-esp-backtrace = { version = "0.5.0", features = [
+esp32s3-hal = "0.7.0"
+esp-backtrace = { version = "0.6.0", features = [
     "esp32s3",
     "panic-handler",
     "print-uart",
 ] }
 xtensa-lx-rt = { version = "0.15.0", features = ["esp32s3"], optional = true }
-esp-println = { version = "0.3.1", features = [ "esp32s3" ] }
+esp-println = { version = "0.4.0", features = [ "esp32s3" ] }
 
 
 [dependencies]
-esp-alloc = "0.1.0"
+esp-alloc = "0.2.0"
 embedded-graphics = "0.7"
 embedded-hal = "0.2"
 display-interface = "0.4"

--- a/m5stack-core2/Cargo.toml
+++ b/m5stack-core2/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 
 [target.xtensa-esp32-none-elf.dependencies]
 xtensa-atomic-emulation-trap = "0.4.0"
-esp32-hal = "0.8.0"
-esp-backtrace = { version = "0.5.0", features = [
+esp32-hal = "0.10.0"
+esp-backtrace = { version = "0.6.0", features = [
     "esp32",
     "panic-handler",
     "print-uart",

--- a/m5stack-fire/Cargo.toml
+++ b/m5stack-fire/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 
 [target.xtensa-esp32-none-elf.dependencies]
 xtensa-atomic-emulation-trap = "0.4.0"
-esp32-hal = "0.8.0"
-esp-backtrace = { version = "0.5.0", features = [
+esp32-hal = "0.10.0"
+esp-backtrace = { version = "0.6.0", features = [
     "esp32",
     "panic-handler",
     "print-uart",


### PR DESCRIPTION
- update all hal and other dependencies
- remove riscv-rt from ESP32-C6 example