### PR TITLE
Feature/esp32 c3 lcdkit

### DIFF
--- a/esp32-c3-lcdkit/.cargo/config.toml
+++ b/esp32-c3-lcdkit/.cargo/config.toml
@@ -1,0 +1,30 @@
+[target.riscv32imac-unknown-none-elf]
+runner = "espflash flash --monitor"
+rustflags = [
+  "-C", "link-arg=-Tlinkall.x",
+  # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
+  # NOTE: May negatively impact performance of produced code
+  "-C", "force-frame-pointers",
+
+  # comment the cfgs below if you do _not_ wish to emulate atomics.
+  # enable the atomic codegen option for RISCV
+  "-C", "target-feature=+a",
+  # tell the core library have atomics even though it's not specified in the target definition
+  "--cfg", "target_has_atomic_load_store",
+  "--cfg", 'target_has_atomic_load_store="8"',
+  "--cfg", 'target_has_atomic_load_store="16"',
+  "--cfg", 'target_has_atomic_load_store="32"',
+  "--cfg", 'target_has_atomic_load_store="ptr"',
+  # enable cas
+  "--cfg", "target_has_atomic",
+  "--cfg", 'target_has_atomic="8"',
+  "--cfg", 'target_has_atomic="16"',
+  "--cfg", 'target_has_atomic="32"',
+  "--cfg", 'target_has_atomic="ptr"',
+]
+
+[build]
+target = "riscv32imac-unknown-none-elf"
+
+[unstable]
+build-std = [ "core", "alloc" ]

--- a/esp32-c3-lcdkit/Cargo.toml
+++ b/esp32-c3-lcdkit/Cargo.toml
@@ -29,6 +29,7 @@ shared-bus = { version = "0.3.0" }
 spooky-core = { path = "../spooky-core", default-features = false, features = ["static_maze"]}
 spooky-embedded = { path = "../spooky-embedded", default-features = false, features = [ "static_maze" ] }
 heapless = { version = "0.7.14", default-features = false }
+rotary-encoder-embedded = "0.2.0"
 
 [features]
 default = [ "esp32c3_ili9341" ]

--- a/esp32-c3-lcdkit/Cargo.toml
+++ b/esp32-c3-lcdkit/Cargo.toml
@@ -22,7 +22,8 @@ embedded-hal = "0.2"
 display-interface = "0.4"
 display-interface-spi = "0.4"
 icm42670 = { git = "https://github.com/jessebraham/icm42670/" }
-mipidsi = "0.7.1"
+#mipidsi = "0.7.1"
+mipidsi = { git = "https://github.com/almindor/mipidsi.git", branch = "master" }
 panic-halt = "0.2"
 shared-bus = { version = "0.3.0" }
 spooky-core = { path = "../spooky-core", default-features = false, features = ["static_maze"]}

--- a/esp32-c3-lcdkit/Cargo.toml
+++ b/esp32-c3-lcdkit/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "spooky-esp32-c3-lcdkit"
+version = "0.6.0"
+authors = ["Juraj Michálek <juraj.michalek@gmail.com>"]
+edition = "2021"
+license = "MIT"
+
+[target.riscv32imac-unknown-none-elf.dependencies]
+hal = { package = "esp32c3-hal", version = "0.12.0" }
+esp-backtrace = { version = "0.8.0", features = [
+    "esp32c3",
+    "panic-handler",
+    "print-uart",
+] }
+esp-println = { version = "0.6.0", features = [ "esp32c3" ] }
+
+[dependencies]
+esp-alloc = "0.3.0"
+embedded-graphics = "0.8.0"
+embedded-graphics-framebuf = { version = "0.3.0", git = "https://github.com/georgik/embedded-graphics-framebuf.git", branch = "feature/embedded-graphics-0.8" }
+embedded-hal = "0.2"
+display-interface = "0.4"
+display-interface-spi = "0.4"
+icm42670 = { git = "https://github.com/jessebraham/icm42670/" }
+mipidsi = "0.7.1"
+panic-halt = "0.2"
+shared-bus = { version = "0.3.0" }
+spooky-core = { path = "../spooky-core", default-features = false, features = ["static_maze"]}
+spooky-embedded = { path = "../spooky-embedded", default-features = false, features = [ "static_maze" ] }
+heapless = { version = "0.7.14", default-features = false }
+
+[features]
+default = [ "esp32c3_ili9341" ]
+system_timer = []
+
+button_controls = []
+imu_controls = []
+
+esp32 = []
+esp32s2 = ["system_timer"]
+esp32s3 = []
+esp32c3 = ["system_timer"]
+
+esp32c3_ili9341 = [ "esp32c3", "imu_controls" ]

--- a/esp32-c3-lcdkit/diagram.json
+++ b/esp32-c3-lcdkit/diagram.json
@@ -1,0 +1,36 @@
+{
+    "version": 1,
+    "author": "Juraj Michálek",
+    "editor": "wokwi",
+    "parts": [
+      {
+        "type": "board-esp32-c3-rust-1",
+        "id": "esp",
+        "top": -494.32,
+        "left": -455.03,
+        "attrs": { "builder": "rust-std-esp32" }
+      },
+      {
+        "type": "wokwi-ili9341",
+        "id": "lcd1",
+        "top": -546.22,
+        "left": -134.92,
+        "rotate": 90,
+        "attrs": {}
+      }
+    ],
+    "connections": [
+      [ "esp:TX0", "$serialMonitor:RX", "", [] ],
+      [ "esp:RX0", "$serialMonitor:TX", "", [] ],
+      [ "esp:3V3", "lcd1:VCC", "green", [] ],
+      [ "esp:GND.1", "lcd1:GND", "black", [] ],
+      [ "esp:6", "lcd1:SCK", "blue", [] ],
+      [ "esp:7", "lcd1:MOSI", "orange", [] ],
+      [ "esp:20", "lcd1:CS", "red", [] ],
+      [ "esp:21", "lcd1:D/C", "magenta", [] ],
+      [ "esp:3", "lcd1:RST", "yellow", [] ],
+      [ "lcd1:LED", "esp:3V3", "white", [] ]
+    ],
+    "serialMonitor": { "display": "terminal" },
+    "dependencies": {}
+  }

--- a/esp32-c3-lcdkit/diagram.json
+++ b/esp32-c3-lcdkit/diagram.json
@@ -4,7 +4,7 @@
     "editor": "wokwi",
     "parts": [
       {
-        "type": "board-esp32-c3-rust-1",
+        "type": "board-esp32-c3-devkitm-1",
         "id": "esp",
         "top": -494.32,
         "left": -455.03,
@@ -18,7 +18,7 @@
         "rotate": 90,
         "attrs": {}
       },
-      { "type": "wokwi-ky-040", "id": "encoder1", "top": -17.5, "left": -173.6, "attrs": {} }
+      { "type": "wokwi-ky-040", "id": "encoder1", "top": -417.5, "left": -703.6, "attrs": {} }
     ],
     "connections": [
       [
@@ -40,8 +40,17 @@
       [ "esp:20", "lcd1:CS", "red", [] ],
       [ "esp:21", "lcd1:D/C", "magenta", [] ],
       [ "esp:3", "lcd1:RST", "yellow", [] ],
-      [ "lcd1:LED", "esp:3V3", "white", [] ]
+      [ "lcd1:LED", "esp:3V3", "white", [] ],
+      [ "esp:10", "encoder1:DT", "green", [] ],
+      [ "esp:9", "encoder1:CLK", "blue", [] ],
+      [ "esp:3V3", "encoder1:VCC", "red", [] ],
+      [ "esp:GND.1", "encoder1:GND", "black", [] ],
+      [ "esp:8", "encoder1:SW", "yellow", [] ]
     ],
-    "serialMonitor": { "display": "terminal" },
+    "serialMonitor": {
+      "display": "terminal",
+      "newline": "lf",
+      "convertEol": true
+    },
     "dependencies": {}
   }

--- a/esp32-c3-lcdkit/diagram.json
+++ b/esp32-c3-lcdkit/diagram.json
@@ -17,11 +17,22 @@
         "left": -134.92,
         "rotate": 90,
         "attrs": {}
-      }
+      },
+      { "type": "wokwi-ky-040", "id": "encoder1", "top": -17.5, "left": -173.6, "attrs": {} }
     ],
     "connections": [
-      [ "esp:TX0", "$serialMonitor:RX", "", [] ],
-      [ "esp:RX0", "$serialMonitor:TX", "", [] ],
+      [
+        "esp:TX",
+        "$serialMonitor:RX",
+        "",
+        []
+      ],
+      [
+        "esp:RX",
+        "$serialMonitor:TX",
+        "",
+        []
+      ],
       [ "esp:3V3", "lcd1:VCC", "green", [] ],
       [ "esp:GND.1", "lcd1:GND", "black", [] ],
       [ "esp:6", "lcd1:SCK", "blue", [] ],

--- a/esp32-c3-lcdkit/rust-toolchain.toml
+++ b/esp32-c3-lcdkit/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "rustc-dev"]
+# targets = ["xtensa-esp32s3-none-elf"]
+# targets = ["xtensa-esp32-none-elf", "xtensa-esp32s2-none-elf","xtensa-esp32s3-none-elf"]

--- a/esp32-c3-lcdkit/src/accel_movement_controller.rs
+++ b/esp32-c3-lcdkit/src/accel_movement_controller.rs
@@ -1,0 +1,53 @@
+use spooky_core::engine::Action;
+use spooky_core::movement_controller::MovementController;
+use icm42670::accelerometer::Accelerometer;
+pub struct AccelMovementController<I>
+where
+    I: Accelerometer,
+{
+    icm: I,
+    last_action: Action,
+    accel_threshold: f32,
+}
+
+impl<I> AccelMovementController<I>
+where
+    I: Accelerometer,
+{
+    pub fn new(icm: I, accel_threshold: f32) -> Self {
+        Self {
+            icm,
+            last_action: Action::None,
+            accel_threshold,
+        }
+    }
+}
+
+impl<I> MovementController for AccelMovementController<I>
+where
+    I: Accelerometer,
+{
+    fn set_active(&mut self, _index:usize) {
+    }
+
+    fn get_movement(&self) -> Action {
+        self.last_action
+    }
+
+    fn tick(&mut self) {
+        if let Ok(accel_norm) = self.icm.accel_norm() {
+            if accel_norm.y > self.accel_threshold {
+                self.last_action = Action::Left;
+            } else if accel_norm.y < -self.accel_threshold {
+                self.last_action = Action::Right;
+            } else if accel_norm.x > self.accel_threshold {
+                self.last_action = Action::Down;
+            } else if accel_norm.x < -self.accel_threshold {
+                self.last_action = Action::Up;
+            } else {
+                self.last_action = Action::None;
+            }
+            // Additional actions for Teleport and PlaceDynamite can be added here
+        }
+    }
+}

--- a/esp32-c3-lcdkit/src/app.rs
+++ b/esp32-c3-lcdkit/src/app.rs
@@ -19,8 +19,8 @@ where
     let demo_movement_controller = spooky_core::demo_movement_controller::DemoMovementController::new(seed_buffer);
     // let movement_controller = S3BoxCompositeController::new(demo_movement_controller, accel_movement_controller);
 
-    let mut data = [Rgb565::BLACK; 320 * 240];
-    let fbuf = FrameBuf::new(&mut data, 320, 240);
+    let mut data = [Rgb565::BLACK; 240 * 240];
+    let fbuf = FrameBuf::new(&mut data, 240, 240);
     let spritebuf = SpriteBuf::new(fbuf);
 
     let engine = Engine::new(spritebuf, Some(seed_buffer));

--- a/esp32-c3-lcdkit/src/app.rs
+++ b/esp32-c3-lcdkit/src/app.rs
@@ -9,15 +9,15 @@ use crate::Accelerometer;
 pub fn app_loop<DISP>(
     display: &mut DISP,
     seed_buffer: [u8; 32],
-    icm: impl Accelerometer // You'll need to pass your accelerometer device here
+    // icm: impl Accelerometer // You'll need to pass your accelerometer device here
 )
 where
     DISP: DrawTarget<Color = Rgb565>,
 {
-    let accel_movement_controller = AccelMovementController::new(icm, 0.2);
+    // let accel_movement_controller = AccelMovementController::new(icm, 0.2);
 
     let demo_movement_controller = spooky_core::demo_movement_controller::DemoMovementController::new(seed_buffer);
-    let movement_controller = S3BoxCompositeController::new(demo_movement_controller, accel_movement_controller);
+    // let movement_controller = S3BoxCompositeController::new(demo_movement_controller, accel_movement_controller);
 
     let mut data = [Rgb565::BLACK; 320 * 240];
     let fbuf = FrameBuf::new(&mut data, 320, 240);
@@ -25,7 +25,7 @@ where
 
     let engine = Engine::new(spritebuf, Some(seed_buffer));
 
-    let mut universe = Universe::new_with_movement_controller(engine, movement_controller);
+    let mut universe = Universe::new_with_movement_controller(engine, demo_movement_controller);
 
     universe.initialize();
 

--- a/esp32-c3-lcdkit/src/app.rs
+++ b/esp32-c3-lcdkit/src/app.rs
@@ -1,0 +1,36 @@
+use crate::s3box_composite_controller::S3BoxCompositeController;
+use embedded_graphics::{pixelcolor::Rgb565, prelude::DrawTarget};
+use spooky_core::{engine::Engine, spritebuf::SpriteBuf, universe::Universe};
+use embedded_graphics_framebuf::FrameBuf;
+use embedded_graphics::prelude::RgbColor;
+use crate::accel_movement_controller::AccelMovementController;
+use crate::Accelerometer;
+
+pub fn app_loop<DISP>(
+    display: &mut DISP,
+    seed_buffer: [u8; 32],
+    icm: impl Accelerometer // You'll need to pass your accelerometer device here
+)
+where
+    DISP: DrawTarget<Color = Rgb565>,
+{
+    let accel_movement_controller = AccelMovementController::new(icm, 0.2);
+
+    let demo_movement_controller = spooky_core::demo_movement_controller::DemoMovementController::new(seed_buffer);
+    let movement_controller = S3BoxCompositeController::new(demo_movement_controller, accel_movement_controller);
+
+    let mut data = [Rgb565::BLACK; 320 * 240];
+    let fbuf = FrameBuf::new(&mut data, 320, 240);
+    let spritebuf = SpriteBuf::new(fbuf);
+
+    let engine = Engine::new(spritebuf, Some(seed_buffer));
+
+    let mut universe = Universe::new_with_movement_controller(engine, movement_controller);
+
+    universe.initialize();
+
+    loop {
+        let _ = display
+            .draw_iter(universe.render_frame().into_iter());
+    }
+}

--- a/esp32-c3-lcdkit/src/main.rs
+++ b/esp32-c3-lcdkit/src/main.rs
@@ -1,0 +1,125 @@
+#![no_std]
+#![no_main]
+
+#[global_allocator]
+static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
+
+use display_interface_spi::SPIInterfaceNoCS;
+use embedded_graphics::{
+    mono_font::{ascii::FONT_8X13, MonoTextStyle},
+    prelude::{Point, RgbColor},
+    text::Text,
+    Drawable,
+};
+
+use esp_println::println;
+
+use hal::{
+    clock::{ClockControl, CpuClock},
+    // gdma::Gdma,
+    i2c,
+    peripherals::Peripherals,
+    prelude::*,
+    spi,
+    Delay,
+    Rng,
+    IO
+};
+
+mod app;
+use app::app_loop;
+
+mod accel_movement_controller;
+mod s3box_composite_controller;
+mod setup;
+use setup::setup_pins;
+
+mod types;
+
+use esp_backtrace as _;
+
+// #[cfg(any(feature = "imu_controls"))]
+use icm42670::{accelerometer::Accelerometer, Address, Icm42670};
+// #[cfg(any(feature = "imu_controls"))]
+use shared_bus::BusManagerSimple;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+    let mut system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
+
+    let mut delay = Delay::new(&clocks);
+
+    println!("About to initialize the SPI LED driver");
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let (unconfigured_pins, /*configured_pins, */mut configured_system_pins) = setup_pins(io.pins);
+    println!("SPI LED driver initialized");
+    let spi = spi::Spi::new_no_cs_no_miso(
+        peripherals.SPI2,
+        unconfigured_pins.sclk,
+        unconfigured_pins.mosi,
+        60u32.MHz(),
+        spi::SpiMode::Mode0,
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    println!("SPI ready");
+
+    let di = SPIInterfaceNoCS::new(spi, configured_system_pins.dc);
+
+    // ESP32-S3-BOX display initialization workaround: Wait for the display to power up.
+    // If delay is 250ms, picture will be fuzzy.
+    // If there is no delay, display is blank
+    delay.delay_ms(500u32);
+
+    let mut display = match mipidsi::Builder::ili9342c_rgb565(di)
+    .with_display_size(240 as u16, 320 as u16)
+    .with_orientation(mipidsi::Orientation::Landscape(true))
+    .with_color_order(mipidsi::ColorOrder::Rgb)
+        .init(&mut delay, Some(configured_system_pins.reset)) {
+        Ok(display) => display,
+        Err(e) => {
+            // Handle the error and possibly exit the application
+            panic!("Display initialization failed");
+        }
+    };
+
+    // configured_system_pins.backlight.set_high();
+
+    println!("Initializing...");
+        Text::new(
+            "Initializing...",
+            Point::new(80, 110),
+            MonoTextStyle::new(&FONT_8X13, RgbColor::WHITE),
+        )
+        .draw(&mut display)
+        .unwrap();
+
+
+
+    // #[cfg(any(feature = "imu_controls"))]
+    let i2c = i2c::I2C::new(
+        peripherals.I2C0,
+        unconfigured_pins.sda,
+        unconfigured_pins.scl,
+        100u32.kHz(),
+        &mut system.peripheral_clock_control,
+        &clocks,
+    );
+
+    // #[cfg(any(feature = "imu_controls"))]
+    let bus = BusManagerSimple::new(i2c);
+    // #[cfg(any(feature = "imu_controls"))]
+    let icm = Icm42670::new(bus.acquire_i2c(), Address::Primary).unwrap();
+
+    let mut rng = Rng::new(peripherals.RNG);
+    let mut seed_buffer = [0u8; 32];
+    rng.read(&mut seed_buffer).unwrap();
+
+
+    app_loop( &mut display, seed_buffer, icm);
+    loop {}
+
+}

--- a/esp32-c3-lcdkit/src/main.rs
+++ b/esp32-c3-lcdkit/src/main.rs
@@ -53,6 +53,7 @@ fn main() -> ! {
 
     println!("About to initialize the SPI LED driver");
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    // https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c3/esp32-c3-lcdkit/user_guide.html#gpio-allocation
     let (unconfigured_pins, /*configured_pins, */mut configured_system_pins) = setup_pins(io.pins);
     println!("SPI LED driver initialized");
     let spi = spi::Spi::new_no_cs_no_miso(
@@ -74,7 +75,7 @@ fn main() -> ! {
     // If there is no delay, display is blank
     delay.delay_ms(500u32);
 
-    let mut display = match mipidsi::Builder::ili9342c_rgb565(di)
+    let mut display = match mipidsi::Builder::gc9a01(di)
     .with_display_size(240 as u16, 320 as u16)
     .with_orientation(mipidsi::Orientation::Landscape(true))
     .with_color_order(mipidsi::ColorOrder::Rgb)

--- a/esp32-c3-lcdkit/src/main.rs
+++ b/esp32-c3-lcdkit/src/main.rs
@@ -32,6 +32,7 @@ use app::app_loop;
 mod accel_movement_controller;
 mod s3box_composite_controller;
 mod setup;
+use rotary_encoder_embedded::{ RotaryEncoder, Direction };
 use setup::setup_pins;
 
 mod types;
@@ -69,7 +70,7 @@ fn main() -> ! {
     println!("About to initialize the SPI LED driver");
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     // https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c3/esp32-c3-lcdkit/user_guide.html#gpio-allocation
-    let (uninitialized_pins, /*configured_pins, */mut configured_system_pins) = setup_pins(io.pins);
+    let (uninitialized_pins, mut configured_system_pins, mut rotary_pins) = setup_pins(io.pins);
     println!("SPI LED driver initialized");
     let spi = spi::Spi::new(
         peripherals.SPI2,
@@ -134,9 +135,28 @@ fn main() -> ! {
     let mut seed_buffer = [0u8; 32];
     rng.read(&mut seed_buffer).unwrap();
 
+    let mut rotary_encoder = RotaryEncoder::new(
+        rotary_pins.dt,
+        rotary_pins.clk,
+    ).into_standard_mode();
 
     // app_loop( &mut display, seed_buffer, icm);
     println!("Starting application loop");
+    // loop {
+    //     rotary_encoder.update();
+    //     match rotary_encoder.direction() {
+    //         Direction::Clockwise => {
+    //             println!("Clockwise");
+    //         }
+    //         Direction::Anticlockwise => {
+    //             println!("Anticlockwise");
+    //         }
+    //         Direction::None => {
+    //             println!("None");
+    //         }
+    //     }
+    //     delay.delay_ms(100u32);
+    // }
     app_loop( &mut display, seed_buffer);
     loop {}
 

--- a/esp32-c3-lcdkit/src/s3box_composite_controller.rs
+++ b/esp32-c3-lcdkit/src/s3box_composite_controller.rs
@@ -1,0 +1,73 @@
+use spooky_core::engine::Action;
+use spooky_core::movement_controller::MovementController;
+use spooky_core::demo_movement_controller::DemoMovementController;
+use crate::accel_movement_controller::AccelMovementController;
+use icm42670::accelerometer::Accelerometer;
+
+pub struct S3BoxCompositeController<I>
+where
+    I: Accelerometer,
+{
+    demo_controller: DemoMovementController,
+    accel_controller: AccelMovementController<I>,
+    active_index: usize, // 0 for demo_controller, 1 for accel_controller
+    last_action: Action,
+    last_accel_action: Action,
+}
+
+impl<I> S3BoxCompositeController<I>
+where
+    I: Accelerometer,
+{
+    pub fn new(demo_controller: DemoMovementController, accel_controller: AccelMovementController<I>) -> Self {
+        Self {
+            demo_controller,
+            accel_controller,
+            active_index: 0,
+            last_action: Action::None,
+            last_accel_action: Action::None,
+        }
+    }
+}
+
+impl<I> MovementController for S3BoxCompositeController<I>
+where
+    I: Accelerometer,
+{
+    fn tick(&mut self) {
+        self.last_action = Action::None;
+        match self.active_index {
+            0 => {
+                self.accel_controller.tick();
+                let current_accel_action = self.accel_controller.get_movement();
+                // Initialization state of accelerometer
+                if self.last_accel_action == Action::None {
+                    self.last_accel_action = current_accel_action;
+                } else if self.last_accel_action != current_accel_action {
+                    // 2nd change of state, we consider it as signal to start the game mode
+                    self.last_action = Action::Start;
+                    self.set_active(1);
+                }
+                self.demo_controller.tick()
+            },
+            1 => self.accel_controller.tick(),
+            _ => {}
+        }
+    }
+
+    fn get_movement(&self) -> Action {
+        if self.last_action != Action::None {
+            return self.last_action;
+        }
+
+        match self.active_index {
+            0 => self.demo_controller.get_movement(),
+            1 => self.accel_controller.get_movement(),
+            _ => Action::None,
+        }
+    }
+
+    fn set_active(&mut self, index: usize) {
+        self.active_index = index;
+    }
+}

--- a/esp32-c3-lcdkit/src/setup.rs
+++ b/esp32-c3-lcdkit/src/setup.rs
@@ -1,0 +1,61 @@
+use crate::types::{UnconfiguredPins, ConfiguredPins, ConfiguredSystemPins};
+use embedded_hal::digital::v2::{OutputPin, InputPin};
+use hal::gpio::{self, Pins};
+use spooky_embedded::{ button_keyboard::ButtonKeyboard, embedded_movement_controller::EmbeddedMovementController };
+use spooky_core;
+
+pub fn setup_pins(pins: Pins) -> (UnconfiguredPins<gpio::Unknown>, /*ConfiguredPins<impl InputPin, impl InputPin, impl InputPin, impl InputPin, impl InputPin,
+    impl InputPin>, */ConfiguredSystemPins<impl OutputPin, impl OutputPin, impl OutputPin>) {
+            let unconfigured_pins = UnconfiguredPins {
+        sclk: pins.gpio6,
+        mosi: pins.gpio7,
+        sda: pins.gpio8,
+        scl: pins.gpio18,
+    };
+
+    // let configured_pins = ConfiguredPins {
+    //     up_button: pins.gpio14.into_pull_up_input(),
+    //     down_button: pins.gpio12.into_pull_up_input(),
+    //     left_button: pins.gpio13.into_pull_up_input(),
+    //     right_button: pins.gpio15.into_pull_up_input(),
+    //     dynamite_button: pins.gpio26.into_pull_up_input(),
+    //     teleport_button: pins.gpio27.into_pull_up_input(),
+    // };
+
+    let configured_system_pins = ConfiguredSystemPins {
+        dc: pins.gpio21.into_push_pull_output(),
+        backlight: pins.gpio5.into_push_pull_output(),
+        reset: pins.gpio3.into_push_pull_output(),
+    };
+
+    (unconfigured_pins, /*configured_pins, */configured_system_pins)
+}
+
+pub fn setup_button_keyboard<Up: InputPin, Down: InputPin, Left: InputPin, Right: InputPin, Dyn: InputPin, Tel: InputPin>(
+    configured_pins: ConfiguredPins<Up, Down, Left, Right, Dyn, Tel>
+) -> ButtonKeyboard<Up, Down, Left, Right, Dyn, Tel> {
+    ButtonKeyboard::new(
+        configured_pins.up_button,
+        configured_pins.down_button,
+        configured_pins.left_button,
+        configured_pins.right_button,
+        configured_pins.dynamite_button,
+        configured_pins.teleport_button,
+    )
+}
+
+pub fn setup_movement_controller<Up, Down, Left, Right, Dyn, Tel>(
+    seed_buffer: [u8; 32],
+    button_keyboard: ButtonKeyboard<Up, Down, Left, Right, Dyn, Tel>
+) -> EmbeddedMovementController<Up, Down, Left, Right, Dyn, Tel>
+where
+    Up: InputPin,
+    Down: InputPin,
+    Left: InputPin,
+    Right: InputPin,
+    Dyn: InputPin,
+    Tel: InputPin,
+{
+    let demo_movement_controller = spooky_core::demo_movement_controller::DemoMovementController::new(seed_buffer);
+    EmbeddedMovementController::new(demo_movement_controller, button_keyboard)
+}

--- a/esp32-c3-lcdkit/src/setup.rs
+++ b/esp32-c3-lcdkit/src/setup.rs
@@ -8,24 +8,17 @@ pub fn setup_pins(pins: Pins) -> (UnconfiguredPins<gpio::Unknown>, /*ConfiguredP
     impl InputPin>, */ConfiguredSystemPins<impl OutputPin, impl OutputPin, impl OutputPin>) {
             let unconfigured_pins = UnconfiguredPins {
         sclk: pins.gpio6,
-        mosi: pins.gpio7,
-        sda: pins.gpio8,
-        scl: pins.gpio18,
+        mosi: pins.gpio0,
+        miso: pins.gpio4,
+        sda: pins.gpio3,
+        scl: pins.gpio1,
+        cs: pins.gpio7,
     };
 
-    // let configured_pins = ConfiguredPins {
-    //     up_button: pins.gpio14.into_pull_up_input(),
-    //     down_button: pins.gpio12.into_pull_up_input(),
-    //     left_button: pins.gpio13.into_pull_up_input(),
-    //     right_button: pins.gpio15.into_pull_up_input(),
-    //     dynamite_button: pins.gpio26.into_pull_up_input(),
-    //     teleport_button: pins.gpio27.into_pull_up_input(),
-    // };
-
     let configured_system_pins = ConfiguredSystemPins {
-        dc: pins.gpio21.into_push_pull_output(),
+        dc: pins.gpio2.into_push_pull_output(),
         backlight: pins.gpio5.into_push_pull_output(),
-        reset: pins.gpio3.into_push_pull_output(),
+        reset: pins.gpio8.into_push_pull_output(),
     };
 
     (unconfigured_pins, /*configured_pins, */configured_system_pins)

--- a/esp32-c3-lcdkit/src/setup.rs
+++ b/esp32-c3-lcdkit/src/setup.rs
@@ -7,11 +7,11 @@ use spooky_core;
 pub fn setup_pins(pins: Pins) -> (UnconfiguredPins<gpio::Unknown>, /*ConfiguredPins<impl InputPin, impl InputPin, impl InputPin, impl InputPin, impl InputPin,
     impl InputPin>, */ConfiguredSystemPins<impl OutputPin, impl OutputPin, impl OutputPin>) {
             let unconfigured_pins = UnconfiguredPins {
-        sclk: pins.gpio6,
+        sclk: pins.gpio1,
         mosi: pins.gpio0,
         miso: pins.gpio4,
         sda: pins.gpio3,
-        scl: pins.gpio1,
+        scl: pins.gpio6,
         cs: pins.gpio7,
     };
 

--- a/esp32-c3-lcdkit/src/setup.rs
+++ b/esp32-c3-lcdkit/src/setup.rs
@@ -1,17 +1,18 @@
-use crate::types::{UnconfiguredPins, ConfiguredPins, ConfiguredSystemPins};
+use crate::types::{UnconfiguredPins, ConfiguredPins, ConfiguredSystemPins, RotaryPins};
 use embedded_hal::digital::v2::{OutputPin, InputPin};
 use hal::gpio::{self, Pins};
 use spooky_embedded::{ button_keyboard::ButtonKeyboard, embedded_movement_controller::EmbeddedMovementController };
 use spooky_core;
 
-pub fn setup_pins(pins: Pins) -> (UnconfiguredPins<gpio::Unknown>, /*ConfiguredPins<impl InputPin, impl InputPin, impl InputPin, impl InputPin, impl InputPin,
-    impl InputPin>, */ConfiguredSystemPins<impl OutputPin, impl OutputPin, impl OutputPin>) {
+pub fn setup_pins(pins: Pins) -> (UnconfiguredPins<gpio::Unknown>,
+    ConfiguredSystemPins<impl OutputPin, impl OutputPin, impl OutputPin>,
+    RotaryPins<impl InputPin, impl InputPin, impl InputPin> ) {
             let unconfigured_pins = UnconfiguredPins {
         sclk: pins.gpio1,
         mosi: pins.gpio0,
         miso: pins.gpio4,
         sda: pins.gpio3,
-        scl: pins.gpio6,
+        // scl: pins.gpio6,
         cs: pins.gpio7,
     };
 
@@ -21,7 +22,13 @@ pub fn setup_pins(pins: Pins) -> (UnconfiguredPins<gpio::Unknown>, /*ConfiguredP
         reset: pins.gpio8.into_push_pull_output(),
     };
 
-    (unconfigured_pins, /*configured_pins, */configured_system_pins)
+    let rotary_pins = RotaryPins {
+        dt: pins.gpio10.into_pull_up_input(),
+        clk: pins.gpio6.into_pull_up_input(),
+        switch: pins.gpio9.into_pull_up_input(),
+    };
+
+    (unconfigured_pins, /*configured_pins, */configured_system_pins, rotary_pins)
 }
 
 pub fn setup_button_keyboard<Up: InputPin, Down: InputPin, Left: InputPin, Right: InputPin, Dyn: InputPin, Tel: InputPin>(

--- a/esp32-c3-lcdkit/src/types.rs
+++ b/esp32-c3-lcdkit/src/types.rs
@@ -4,9 +4,11 @@ use embedded_hal::digital::v2::{ InputPin, OutputPin };
 // Generic type for unconfigured pins
 pub struct UnconfiguredPins<MODE> {
     pub sclk: gpio::Gpio6<MODE>,
-    pub mosi: gpio::Gpio7<MODE>,
-    pub sda: gpio::Gpio8<MODE>,
-    pub scl: gpio::Gpio18<MODE>,
+    pub mosi: gpio::Gpio0<MODE>,
+    pub miso: gpio::Gpio4<MODE>,
+    pub sda: gpio::Gpio3<MODE>,
+    pub scl: gpio::Gpio1<MODE>,
+    pub cs: gpio::Gpio7<MODE>,
 }
 
 pub struct ConfiguredPins<Up: InputPin, Down: InputPin, Left: InputPin, Right: InputPin, Dyn: InputPin, Tel: InputPin> {

--- a/esp32-c3-lcdkit/src/types.rs
+++ b/esp32-c3-lcdkit/src/types.rs
@@ -3,11 +3,11 @@ use embedded_hal::digital::v2::{ InputPin, OutputPin };
 
 // Generic type for unconfigured pins
 pub struct UnconfiguredPins<MODE> {
-    pub sclk: gpio::Gpio6<MODE>,
+    pub sclk: gpio::Gpio1<MODE>,
     pub mosi: gpio::Gpio0<MODE>,
     pub miso: gpio::Gpio4<MODE>,
     pub sda: gpio::Gpio3<MODE>,
-    pub scl: gpio::Gpio1<MODE>,
+    pub scl: gpio::Gpio6<MODE>,
     pub cs: gpio::Gpio7<MODE>,
 }
 

--- a/esp32-c3-lcdkit/src/types.rs
+++ b/esp32-c3-lcdkit/src/types.rs
@@ -7,7 +7,7 @@ pub struct UnconfiguredPins<MODE> {
     pub mosi: gpio::Gpio0<MODE>,
     pub miso: gpio::Gpio4<MODE>,
     pub sda: gpio::Gpio3<MODE>,
-    pub scl: gpio::Gpio6<MODE>,
+    // pub scl: gpio::Gpio6<MODE>,
     pub cs: gpio::Gpio7<MODE>,
 }
 
@@ -18,6 +18,12 @@ pub struct ConfiguredPins<Up: InputPin, Down: InputPin, Left: InputPin, Right: I
     pub right_button: Right,
     pub dynamite_button: Dyn,
     pub teleport_button: Tel,
+}
+
+pub struct RotaryPins<DT: InputPin, CLK: InputPin, SW: InputPin> {
+    pub dt: DT,
+    pub clk: CLK,
+    pub switch: SW,
 }
 
 pub struct ConfiguredSystemPins<Dc: OutputPin, Bckl: OutputPin, Reset: OutputPin> {

--- a/esp32-c3-lcdkit/src/types.rs
+++ b/esp32-c3-lcdkit/src/types.rs
@@ -1,0 +1,25 @@
+use hal::gpio;
+use embedded_hal::digital::v2::{ InputPin, OutputPin };
+
+// Generic type for unconfigured pins
+pub struct UnconfiguredPins<MODE> {
+    pub sclk: gpio::Gpio6<MODE>,
+    pub mosi: gpio::Gpio7<MODE>,
+    pub sda: gpio::Gpio8<MODE>,
+    pub scl: gpio::Gpio18<MODE>,
+}
+
+pub struct ConfiguredPins<Up: InputPin, Down: InputPin, Left: InputPin, Right: InputPin, Dyn: InputPin, Tel: InputPin> {
+    pub up_button: Up,
+    pub down_button: Down,
+    pub left_button: Left,
+    pub right_button: Right,
+    pub dynamite_button: Dyn,
+    pub teleport_button: Tel,
+}
+
+pub struct ConfiguredSystemPins<Dc: OutputPin, Bckl: OutputPin, Reset: OutputPin> {
+    pub dc: Dc,
+    pub backlight: Bckl,
+    pub reset: Reset,
+}

--- a/esp32-c3-lcdkit/wokwi.toml
+++ b/esp32-c3-lcdkit/wokwi.toml
@@ -1,0 +1,6 @@
+
+
+[wokwi]
+version = 1
+elf = "target/riscv32imac-unknown-none-elf/release/spooky-esp32-c3-lcdkit"
+firmware = "target/riscv32imac-unknown-none-elf/release/spooky-esp32-c3-lcdkit"


### PR DESCRIPTION
Add support for ESP32 C3 LCDKit - https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c3/esp32-c3-lcdkit/user_guide.html
Graphical driver: [GC9A01](https://github.com/almindor/mipidsi/blob/master/mipidsi/src/models/gc9a01.rs)